### PR TITLE
feat: UrlPermissionFilter, SwaggerDocsConfig 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ fun findToken() = (project.findProperty("gpr.key") as String?).nullWhenEmpty() ?
 fun String?.nullWhenEmpty() = if (this.isNullOrEmpty()) null else this
 
 dependencies {
-    api("com.ssu.commerce:vault:beta-2022.05.6")
+    api("com.ssu.commerce:vault:2022.05.1")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     api("org.springframework.boot:spring-boot-starter-web")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
@@ -48,6 +48,9 @@ dependencies {
     api("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+
+    // Document
+    api("org.springdoc:springdoc-openapi-ui:1.6.8")
 }
 
 configurations {

--- a/src/main/kotlin/com/ssu/commerce/core/configs/DataSourceConfig.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/configs/DataSourceConfig.kt
@@ -1,0 +1,31 @@
+package com.ssu.commerce.core.configs
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.context.annotation.Bean
+import javax.sql.DataSource
+
+open class DataSourceConfig(
+    val dataSourceProperties: AbstractDataSourceProperties
+) {
+    @Bean
+    open fun dataSource(): DataSource =
+        DataSourceBuilder.create()
+            .driverClassName(dataSourceProperties.driverClassName)
+            .url(dataSourceProperties.dataSource)
+            .username(dataSourceProperties.userId)
+            .password(dataSourceProperties.password)
+            .build()
+            .also {
+                LoggerFactory.getLogger(DataSourceConfig::class.java)
+                    .info("\uD83D\uDCC2 SSUCommerce ${dataSourceProperties.projectName} DataSource 접속이 되었습니다.")
+            }
+}
+
+interface AbstractDataSourceProperties {
+    var projectName: String
+    var dataSource: String
+    var userId: String
+    var password: String
+    var driverClassName: String
+}

--- a/src/main/kotlin/com/ssu/commerce/core/configs/SwaggerUiConfig.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/configs/SwaggerUiConfig.kt
@@ -1,0 +1,43 @@
+package com.ssu.commerce.core.configs
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springdoc.core.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+@Component
+class SwaggerUiConfig(
+    private val swaggerconfig: SwaggerDocsConfig
+) {
+    @Bean
+    fun usersGroup(): GroupedOpenApi =
+        GroupedOpenApi.builder().group(swaggerconfig.title)
+            .addOperationCustomizer { operation: Operation, handlerMethod: HandlerMethod? ->
+                operation.addSecurityItem(SecurityRequirement().addList("bearer-key"))
+                operation
+            }
+            .addOpenApiCustomiser { openApi: OpenAPI -> openApi.info(Info().title("${swaggerconfig.title} API").version(swaggerconfig.version)) }
+            .packagesToScan(swaggerconfig.basePackage)
+            .build()
+
+    @Bean
+    fun authenticationHeaderConfig(): OpenAPI =
+        OpenAPI().components(
+            Components().addSecuritySchemes(
+                "bearer-key",
+                SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+            )
+        )
+}
+
+interface SwaggerDocsConfig {
+    val basePackage: String
+    val title: String
+    val version: String
+}

--- a/src/main/kotlin/com/ssu/commerce/coretest/CoreApplication.kt
+++ b/src/main/kotlin/com/ssu/commerce/coretest/CoreApplication.kt
@@ -1,11 +1,11 @@
-package com.ssu.commerce.core
+package com.ssu.commerce.coretest
 
-import com.ssu.commerce.vault.config.EnableSsuCommerceVault
+import com.ssu.commerce.core.configs.EnableSsuCommerceCore
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EnableSsuCommerceVault
+@EnableSsuCommerceCore
 class CoreApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/ssu/commerce/coretest/TestController.kt
+++ b/src/main/kotlin/com/ssu/commerce/coretest/TestController.kt
@@ -1,0 +1,15 @@
+package com.ssu.commerce.coretest
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/test")
+class TestController {
+    @GetMapping
+    fun test() = "test"
+
+    @GetMapping("/2")
+    fun test2() = "test2"
+}

--- a/src/main/kotlin/com/ssu/commerce/coretest/configs/SwaggerConfig.kt
+++ b/src/main/kotlin/com/ssu/commerce/coretest/configs/SwaggerConfig.kt
@@ -1,0 +1,11 @@
+package com.ssu.commerce.coretest.configs
+
+import com.ssu.commerce.core.configs.SwaggerDocsConfig
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig : SwaggerDocsConfig {
+    override val basePackage: String = "com.ssu.commerce.coretest"
+    override val title: String = "Core"
+    override val version: String = "test"
+}

--- a/src/main/kotlin/com/ssu/commerce/coretest/configs/UrlPermission.kt
+++ b/src/main/kotlin/com/ssu/commerce/coretest/configs/UrlPermission.kt
@@ -1,0 +1,7 @@
+package com.ssu.commerce.coretest.configs
+
+import com.ssu.commerce.core.configs.UrlPermissionFilter
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class UrlPermission : UrlPermissionFilter

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html

--- a/src/test/kotlin/com/ssu/commerce/coretest/CoreApplicationTests.kt
+++ b/src/test/kotlin/com/ssu/commerce/coretest/CoreApplicationTests.kt
@@ -1,4 +1,4 @@
-package com.ssu.commerce.core
+package com.ssu.commerce.coretest
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bufix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes
보안필터 는 UrlPermissionFilter 을 상속하여 Configuration으로 등록
스웨거 설정은 SwaggerDocsConfig 을 상속하여 Configuration으로 등록
데이터소스 설정은 AbstractDataSourceProperties 을 상속하여 vault에서 값을 가져온 후 Configuration으로 등록 후
DataSourceConfig을 Configuration으로 등록 (단 test 프로필에서는 제외할것)
## Reason for change
중복 코드 발생을 방지하기 위함
## Detailed Description
![image](https://user-images.githubusercontent.com/18184139/169546100-5bcd2cea-3869-4f4f-a71c-33b9b49b87b7.png)


## mention
@always0ne

Resolves: #
See also: #