### PR TITLE
openFeign 프로젝트 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,9 @@ dependencies {
 
     // Document
     api("org.springdoc:springdoc-openapi-ui:1.6.8")
+
+    // HTTP
+    api("org.springframework.cloud:spring-cloud-starter-openfeign:3.1.3")
 }
 
 configurations {

--- a/src/main/kotlin/com/ssu/commerce/core/CoreApplication.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/CoreApplication.kt
@@ -1,9 +1,13 @@
 package com.ssu.commerce.core
 
+import com.ssu.commerce.vault.config.EnableSsuCommerceVault
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableSsuCommerceVault
 class CoreApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/ssu/commerce/core/client/api/AuthApiClient.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/client/api/AuthApiClient.kt
@@ -1,0 +1,23 @@
+package com.ssu.commerce.core.client.api
+
+import com.ssu.commerce.core.security.JwtTokenDto
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+
+@FeignClient("auth", url = "\${ssu-commerce-url.auth}")
+interface AuthApiClient {
+
+    @PostMapping("/sign-in")
+    fun login(@RequestBody signInRequest: SignInRequest): SessionTokens
+}
+
+data class SignInRequest(
+    val id: String,
+    val password: String
+)
+
+data class SessionTokens(
+    val accessToken: JwtTokenDto,
+    val refreshToken: JwtTokenDto
+)

--- a/src/main/kotlin/com/ssu/commerce/core/client/api/FeignCustomSettings.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/client/api/FeignCustomSettings.kt
@@ -1,0 +1,37 @@
+package com.ssu.commerce.core.client.api
+
+import feign.RequestInterceptor
+import feign.Response
+import feign.codec.ErrorDecoder
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.vault.annotation.VaultPropertySource
+import org.springframework.vault.annotation.VaultPropertySources
+
+@Configuration
+@VaultPropertySources(
+    VaultPropertySource(
+        value = ["ssu-commerce-url/\${spring.profiles.active:dev}"],
+        propertyNamePrefix = "ssu-commerce-url."
+    )
+)
+class FeignCustomSettings {
+
+    @Bean
+    fun requestInterceptor(): RequestInterceptor =
+        RequestInterceptor {
+            if (it.url().equals("/sign-in")) return@RequestInterceptor
+
+            it.header("Authorization", "Bearer ${ServerSessionTokenInitializer.getAccessToken()}")
+        }
+
+    @Bean
+    fun errorDecoder(): ErrorDecoder =
+        SsuCommerceFeignErrorDecoder()
+}
+
+class SsuCommerceFeignErrorDecoder : ErrorDecoder {
+    override fun decode(methodKey: String?, response: Response?): Exception {
+        TODO("장애처리에 대한 고민이 필요")
+    }
+}

--- a/src/main/kotlin/com/ssu/commerce/core/client/api/PointApiClient.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/client/api/PointApiClient.kt
@@ -1,0 +1,41 @@
+package com.ssu.commerce.core.client.api
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+@FeignClient("auth", url = "\${ssu-commerce-url.point}")
+interface PointApiClient {
+
+    @PostMapping("/point/transaction")
+    fun requestTransaction(
+        @RequestBody req: PointTransactionRequest
+    ): PointTransactionResponse
+}
+
+data class PointTransactionRequest(
+    val accountId: Long,
+    val transactionId: Long,
+    val transactionType: TransactionType,
+    val transactionAmount: BigDecimal,
+    val description: String
+)
+
+data class PointTransactionResponse(
+    val pointTransactionId: Long,
+    val accountId: Long,
+    val transactionId: Long,
+    val transactionType: TransactionType,
+    val transactionAmount: BigDecimal,
+    val afterBalance: BigDecimal,
+    val description: String,
+    val approvedAt: LocalDateTime
+)
+
+enum class TransactionType(val plus: Boolean) {
+    CHARGE(true),
+    ORDER(false),
+    REWARD(true)
+}

--- a/src/main/kotlin/com/ssu/commerce/core/client/api/ServerSessionTokenInitializer.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/client/api/ServerSessionTokenInitializer.kt
@@ -1,0 +1,44 @@
+package com.ssu.commerce.core.client.api
+
+import org.slf4j.LoggerFactory
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.event.EventListener
+import java.time.Instant
+import java.time.LocalDate.now
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+@Configuration
+class ServerSessionTokenInitializer(
+    private val authApiClient: AuthApiClient
+) {
+    @EventListener(ApplicationStartedEvent::class)
+    fun login() {
+        initTokenInfo(authApiClient.login(SignInRequest("string", "string")))
+    }
+
+    companion object {
+        private lateinit var accessToken: String
+        private lateinit var accessTokenExpiredIn: LocalDateTime
+        private lateinit var refreshToken: String
+        private lateinit var refreshTokenExpiredIn: LocalDateTime
+
+        internal fun getAccessToken() = accessToken
+        internal fun getRefreshToken() = refreshToken
+
+        internal fun checkAccessTokenIsExpired() = accessTokenExpiredIn.isBefore(LocalDateTime.now())
+
+        internal fun initTokenInfo(sessionTokens: SessionTokens) {
+            accessToken = sessionTokens.accessToken.token
+            accessTokenExpiredIn = long2LocalDateTime(sessionTokens.accessToken.expiredIn)
+            refreshToken = sessionTokens.refreshToken.token
+            refreshTokenExpiredIn = long2LocalDateTime(sessionTokens.refreshToken.expiredIn)
+            LoggerFactory.getLogger(ServerSessionTokenInitializer::class.java)
+                .info("\uD83D\uDD11 인증서버로부터 성공적으로 세션을 발급받았습니다. 만료일시={$accessTokenExpiredIn}")
+        }
+
+        private fun long2LocalDateTime(expiredIn: Long) =
+            LocalDateTime.ofInstant(Instant.ofEpochMilli(expiredIn), ZoneId.systemDefault())
+    }
+}

--- a/src/main/kotlin/com/ssu/commerce/core/configs/EnableSsuCommerceCore.kt
+++ b/src/main/kotlin/com/ssu/commerce/core/configs/EnableSsuCommerceCore.kt
@@ -2,6 +2,7 @@ package com.ssu.commerce.core.configs
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition
 import io.swagger.v3.oas.annotations.servers.Server
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Import
@@ -14,4 +15,5 @@ annotation class EnableSsuCommerceCore
 @Configuration
 @OpenAPIDefinition(servers = [Server(url = "/")])
 @ComponentScan(basePackages = ["com.ssu.commerce.core"])
+@EnableFeignClients
 class EnableSsuCommerceCoreConfiguration

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,3 +4,16 @@ springdoc:
     base-package: "com.ssu.commerce"
     title: Core
     version: 0.0.0
+
+spring:
+  main:
+    allow-bean-definition-overriding: true
+
+
+feign:
+  client:
+    config:
+      default:
+        loggerLevel: BASIC
+
+logging.level.com.ssu.commerce.core.client.api: DEBUG

--- a/src/test/kotlin/com/ssu/commerce/core/CoreApplicationTests.kt
+++ b/src/test/kotlin/com/ssu/commerce/core/CoreApplicationTests.kt
@@ -2,8 +2,10 @@ package com.ssu.commerce.core
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootTest(properties = ["spring.profiles.active:test"])
+@EnableFeignClients
 class CoreApplicationTests {
 
     @Test


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bufix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes
![image](https://user-images.githubusercontent.com/18184139/178144954-33f90c96-6ae0-455f-ac78-583e57a11409.png)
테스트로 서버실행시 인증서버에 로그인해서 accessToken을 가져오도록 구현

API 클라이언트는 아래와 같이 생성하면 됨(예시)
![image](https://user-images.githubusercontent.com/18184139/178144976-a51f3c45-55ee-49e4-a15b-832b20b88a05.png)
코어에 REQ RES 두는게 어떤가 하던 의견이 스쳐지나갔음. 논의가 어느정도는 필요할듯

실패전략은 음...생각해봐야할듯. 정책을 정해보고 구현하도록!
## Reason for change

## Detailed Description


## mention
@always0ne

Resolves: #
See also: #