### PR TITLE
QuerydslJPARepositorySupport 추가

### DIFF
--- a/ssu-commerce-cores/build.gradle.kts
+++ b/ssu-commerce-cores/build.gradle.kts
@@ -47,7 +47,7 @@ allprojects {
 
     dependencies {
         implementation("org.jetbrains.kotlin:kotlin-reflect")
-        api("com.ssu.commerce:ssu-commerce-config-client:2024.03.1")
+        api("com.ssu.commerce:ssu-commerce-config-client:2024.04.5")
     }
 
     configurations {

--- a/ssu-commerce-cores/ssu-commerce-core-jpa/build.gradle.kts
+++ b/ssu-commerce-cores/ssu-commerce-core-jpa/build.gradle.kts
@@ -1,10 +1,21 @@
 plugins {
     kotlin("plugin.jpa") version "1.6.10"
+    kotlin("kapt")
 }
 
 dependencies {
+    // spring
     api("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // querydsl
+    api("com.querydsl:querydsl-jpa:5.0.0")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
+
+    // drivers
     runtimeOnly("com.h2database:h2")
     runtimeOnly("mysql:mysql-connector-java")
+
+    // test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    kaptTest("com.querydsl:querydsl-apt:5.0.0:jpa")
 }

--- a/ssu-commerce-cores/ssu-commerce-core-jpa/src/main/kotlin/com/ssu/commerce/core/jpa/querydsl/QuerydslJPARepositorySupport.kt
+++ b/ssu-commerce-cores/ssu-commerce-core-jpa/src/main/kotlin/com/ssu/commerce/core/jpa/querydsl/QuerydslJPARepositorySupport.kt
@@ -1,0 +1,18 @@
+package com.ssu.commerce.core.jpa.querydsl
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+import kotlin.properties.Delegates
+
+abstract class QuerydslJPARepositorySupport(domainClass: Class<*>) : QuerydslRepositorySupport(domainClass) {
+
+    protected var queryFactory: JPAQueryFactory by Delegates.notNull()
+
+    @PersistenceContext
+    override fun setEntityManager(entityManager: EntityManager) {
+        this.queryFactory = JPAQueryFactory(entityManager)
+        super.setEntityManager(entityManager)
+    }
+}


### PR DESCRIPTION
<!--
title must use prefix like this
feat: new feature
fix: bufix
docs: document changes
style: changes except codes(like indent, import..)
refactor: refactoring
test: test code
chore: about build or deploy(not changes code)
-->

## Changes
querydsl 세팅을 공통화 한다.
## Reason for change
querydsl 관련 중복 설정 제거
## Detailed Description
### 필요 gradle 설정
```kotlin
// build.gradle.kts
plugins {
    kotlin("kapt")
}

dependencies {
    implementation("com.ssu.commerce:ssu-commerce-core-jpa:${properties["ssu-commerce-core"]}")
    kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
```
### repository 구현
```kotlin
interface TestEntityRepository : JpaRepository<TestEntity, Long>, TestCustomRepository

interface TestQuerydslRepository {
    fun findByNameByQdsl(name: String): TestEntity?
}

class TTestQuerydslRepositoryImpl : TestQuerydslRepository, QuerydslJPARepositorySupport(TestEntity::class.java) {
    override fun findByNameByQdsl(name: String): TestEntity? =
        queryFactory.select(testEntity)
            .from(testEntity)
            .where(testEntity.name.eq(name))
            .fetchOne()
}
```

## mention
@always0ne

Resolves: #
See also: #